### PR TITLE
made text gray by default and moved car in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ where scene is an iterable of renderable objects including cars and roadways.
 Example:
 ```julia
 roadway = gen_straight_roadway(3, 100.0)
-car = ArrowCar([0.0, 0.0], 0.0, color=colorant"blue") # [north, east], angle
+car = ArrowCar([50.0, 0.0], 0.0, color=colorant"blue") # [north, east], angle
 render([roadway, car, "some text"])
 ```
 

--- a/src/text.jl
+++ b/src/text.jl
@@ -6,7 +6,7 @@ function render!(rm::RenderModel, t::String)
     y = 1.5*font_size
     y_jump = 1.5 * font_size
     for line in split(t, '\n')
-        add_instruction!(rm, render_text, (line, x, y, font_size, colorant"white"), incameraframe=false)
+        add_instruction!(rm, render_text, (line, x, y, font_size, colorant"gray75"), incameraframe=false)
         y += y_jump
     end
     return rm


### PR DESCRIPTION
Gray text will show up on a white background (e.g. if you are using ElectronDisplay).

@MaximeBouton can you merge this if it seems ok to you?