### PR TITLE
font rendering bugfix

### DIFF
--- a/src/rendermodels.jl
+++ b/src/rendermodels.jl
@@ -94,9 +94,7 @@ end
 function render_to_canvas(rendermodel::RenderModel, ctx::CairoContext, canvas_width::Integer, canvas_height::Integer)
 
     # fill with background color
-    bgc = rendermodel.background_color
-    r,g,b,a = red(bgc), green(bgc), blue(bgc), alpha(bgc)
-    set_source_rgba(ctx, a,r,g,b)
+    set_source_rgba(ctx, rendermodel.background_color)
     paint(ctx)
 
     # render text if no other instructions


### PR DESCRIPTION
Font rendering on my Linux machine was terrible. My guess is Cairo was using the wrong background color for antialiasing.

Before:
![Screenshot from 2019-12-19 14-19-16](https://user-images.githubusercontent.com/53627988/71215377-671d3080-226c-11ea-8b25-aa4237c959a0.png)

After:
![Screenshot from 2019-12-19 14-20-22](https://user-images.githubusercontent.com/53627988/71215398-7603e300-226c-11ea-9af7-cbd94cc3848b.png)

Not sure why exactly this small change fixed the issue.
Related link: https://github.com/JuliaGraphics/Cairo.jl/issues/138