### PR TITLE
camera_fit_to_content default, remove FitToContentCamera

### DIFF
--- a/notebooks/autoviz_tutorial.ipynb
+++ b/notebooks/autoviz_tutorial.ipynb
@@ -74,7 +74,7 @@
    ],
    "source": [
     "roadway = gen_stadium_roadway(2)\n",
-    "render([roadway], camera=FitToContentCamera(0.0))"
+    "render([roadway])"
    ]
   },
   {

--- a/src/AutoViz.jl
+++ b/src/AutoViz.jl
@@ -47,7 +47,6 @@ export
     ZoomingCamera,
     ComposedCamera,
     SceneFollowCamera,
-    FitToContentCamera,
     set_camera!,
     camera_move!,
     camera_move_pix!,

--- a/src/cameras.jl
+++ b/src/cameras.jl
@@ -187,19 +187,3 @@ function update_camera!(camera::ComposedCamera, scene::Frame{E}) where {E<:Entit
         update_camera!(camera.cs, cam, scene)
     end
 end
-
-"""
-    FitToContentCamera
-
-Move the camera such that all rendered content fits the canvas.
-The camera rotation will always be set to 0. An additional border can be added around the content using the argument `percent_border`.
-
-# Constructor 
-
-`FitToContentCamera(percent_border::Float64)`
-"""
-mutable struct FitToContentCamera <: Camera
-    state::CameraState
-    percent_border::Float64
-end
-FitToContentCamera(percent_border::Float64;kwargs...) = FitToContentCamera(CameraState(;kwargs...), percent_border)


### PR DESCRIPTION
make `camera_fit_to_content` the new default, i.e. if no camera is passed to the render function. Remove `FitToContentCamera` which is inconsistent with all the other cameras.